### PR TITLE
Could not update sms response

### DIFF
--- a/org_civicrm_sms_clickatell.php
+++ b/org_civicrm_sms_clickatell.php
@@ -93,6 +93,8 @@ class org_civicrm_sms_clickatell extends CRM_SMS_Provider {
     '010' => 'Message expired',
     '011' => 'Message queued for later delivery',
     '012' => 'Out of credit',
+    '013' => 'Clickatell cancelled message delivery',
+    '014' => 'Maximum MT limit exceeded',
   );
 
   /**
@@ -385,6 +387,16 @@ class org_civicrm_sms_clickatell extends CRM_SMS_Provider {
         case "012":
           $statusID = $actStatusIDs['Cancelled'];
           $clickStat = $this->_messageStatus[$status] . " - Out of Credit";
+          break;
+
+        case "013":
+          $statusID = $actStatusIDs['Cancelled'];
+          $clickStat = $this->_messageStatus[$status] . " - Clickatell cancelled message delivery";
+          break;
+
+        case "014":
+          $statusID = $actStatusIDs['Cancelled'];
+          $clickStat = $this->_messageStatus[$status] . " - Maximum MT limit exceeded";
           break;
       }
 

--- a/org_civicrm_sms_clickatell.php
+++ b/org_civicrm_sms_clickatell.php
@@ -409,10 +409,16 @@ class org_civicrm_sms_clickatell extends CRM_SMS_Provider {
         CRM_Core_Error::debug_log_message("SMS Response updated for apiMsgId={$apiMsgID}.");
         return TRUE;
       }
+      else {
+        $trace = "unhandled status value of '{$status}'";
+      }
+    }
+    else {
+      $trace = "could not find activity matching that Id";
     }
 
     // if no update is done
-    CRM_Core_Error::debug_log_message("Could not update SMS Response for apiMsgId={$apiMsgID}.");
+    CRM_Core_Error::debug_log_message("Could not update SMS Response for apiMsgId={$apiMsgID} - {$trace}");
     return FALSE;
   }
 


### PR DESCRIPTION
While investigating log messages saying "Could not update SMS Response for apiMsgId=**************" I noticed
1. That two message status values (013 and 014) were not being handled (see https://www.clickatell.com/developers/api-docs/message-status-codes/) and
2. The log message didn't tell me enough information about the problem.

This PR fixes those 2 issues.
