### PR TITLE
Support for old and new clickatell accounts

### DIFF
--- a/org_civicrm_sms_clickatell.php
+++ b/org_civicrm_sms_clickatell.php
@@ -458,13 +458,28 @@ class org_civicrm_sms_clickatell extends CRM_SMS_Provider {
    * @access	private
    */
   function curl($url, $postData) {
-
+	  
+	// JS 25042018 - If user uses the url "https://api.clickatell.com/" in CiviCRM SMS provider Settings
+	if($this->_providerInfo['api_url'] == "https://api.clickatell.com")
+    {
+	//Url for Old Credentials	
+	$user = $this->_providerInfo['username'];
+	$password = $this->_providerInfo['password'];
+	$api_id1 = $this->_providerInfo['api_params']['api_id'];
+	$params1 = 'user=' . $user . '&password=' . $password .'&api_id=' . $api_id1;
+	$chUrl = "https://api.clickatell.com/http/sendmsg?" . $params1 . '&' . $postData;
+    CRM_Core_Error::debug_var('churl', $chUrl);
+    }
+	
+	else
+	{
+	//Url for New Credentials
     // cliackatell apiKey requires '==' to be passed with the apikey!!!
     $apiKey = $this->_providerInfo['api_params']['api_id'].'==';
     // include apiKey in the params
     $params = $postData . '&apiKey=' . $apiKey;
-
     $chUrl = $url . '?' . $params;
+    }  
 
     curl_setopt($this->_ch, CURLOPT_URL, $chUrl);
     curl_setopt($this->_ch, CURLOPT_SSL_VERIFYHOST, Civi::settings()->get('verifySSL') ? 2 : 0);
@@ -476,26 +491,8 @@ class org_civicrm_sms_clickatell extends CRM_SMS_Provider {
     // Send the data out over the wire
     $responseData = curl_exec($this->_ch);
 	
-    // JS 25042018 - If user uses the url "https://api.clickatell.com/" in CiviCRM SMS provider Settings
-	if($this->_providerInfo['api_url'] == "https://api.clickatell.com")
-    {
-	$user = $this->_providerInfo['username'];
-	$password = $this->_providerInfo['password'];
-	$api_id1 = $this->_providerInfo['api_params']['api_id'];
-	$params1 = 'user=' . $user . '&password=' . $password .'&api_id=' . $api_id1;
-	$chUrl = "https://api.clickatell.com/http/sendmsg?" . $params1 . '&' . $postData;
-    CRM_Core_Error::debug_var('churl1', $chUrl);
-    curl_setopt($this->_ch, CURLOPT_URL, $chUrl);
-    curl_setopt($this->_ch, CURLOPT_SSL_VERIFYHOST, Civi::settings()->get('verifySSL') ? 2 : 0);
-    curl_setopt($this->_ch, CURLOPT_SSL_VERIFYPEER, Civi::settings()->get('verifySSL'));
-    // return the result on success, FALSE on failure
-    curl_setopt($this->_ch, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($this->_ch, CURLOPT_TIMEOUT, 36000);
-    $responseData = curl_exec($this->_ch);
-	}
-	 
-
-    if (!$responseData) {
+     if (!$responseData) 
+	{
       $erroMessage = 'Error: "' . curl_error($this->_ch) . '" - Code: ' . curl_errno($this->_ch);
       CRM_Core_Session::setStatus(ts($erroMessage), ts('API Error'), 'error');
     }


### PR DESCRIPTION
Added a 'if'  condition so that it works both Old and New Clickatell accounts.
	 
	 Edited line Numbers -> 262 and (480-494)
	 
	 This works for both Old and New Clickatell Users, provided 
	 ->Old Clickatell users use "https://api.clickatell.com/" in CiviCRM SMS provider Settings
	 ->New Clickatell users use "https://Platform.clickatell.com/" in CiviCRM SMS provider Settings