### PR TITLE
Wrong variable

### DIFF
--- a/org_civicrm_sms_clickatell.php
+++ b/org_civicrm_sms_clickatell.php
@@ -306,7 +306,7 @@ class org_civicrm_sms_clickatell extends CRM_SMS_Provider {
         $errorMessage = $response['error'];
         CRM_Core_Session::setStatus(ts($errorMessage), ts('Sending SMS Error'), 'error');
         // TODO: Should add a failed activity instead.
-        CRM_Core_Error::debug_log_message($response . " - for phone: {$postDataArray['to']}");
+        CRM_Core_Error::debug_log_message($errorMessage . " - for phone: {$postDataArray['to']}");
         return;
       } else {
         $data = $response['messages'][0];


### PR DESCRIPTION
$response is an array and the function CRM_Core_Error::debug_log_message() was especting a string causing a php error "Array to string conversion"