### PR TITLE
remove utf8_decode

### DIFF
--- a/org_civicrm_sms_clickatell.php
+++ b/org_civicrm_sms_clickatell.php
@@ -256,9 +256,9 @@ class org_civicrm_sms_clickatell extends CRM_SMS_Provider {
       }
       //TODO:
       $postDataArray['to']   = $header['To'];
-	   // JS 25042018 - Content for Second Url
-	  $postDataArray['text'] = utf8_decode(substr($message, 0, 460)); // max of 460 characters, is probably not multi-lingual
-      $postDataArray['content'] = utf8_decode(substr($message, 0, 460)); // max of 460 characters, is probably not multi-lingual
+      // JS 25042018 - Content for Second Url
+      $postDataArray['text'] = substr($message, 0, 460); // max of 460 characters, is probably not multi-lingual
+      $postDataArray['content'] = substr($message, 0, 460); // max of 460 characters, is probably not multi-lingual
       if (array_key_exists('mo', $this->_providerInfo['api_params'])) {
         $postDataArray['mo'] = $this->_providerInfo['api_params']['mo'];
       }


### PR DESCRIPTION
The extension uses `utf8_decode()` function [here](https://github.com/veda-consulting/org.civicrm.sms.clickatell/blob/v4.1/org_civicrm_sms_clickatell.php#L262) to decode the message text from a UTF-8 string to ISO-8859-1 before posting to Clickatell. 

Hence Clickatell manages UTF-8 messages, the use of `utf8_decode()` is not necessary, it causes unicode issues when sending non-English characters in text body.