### PR TITLE
Process Inbound SMS

### DIFF
--- a/org_civicrm_sms_clickatell.php
+++ b/org_civicrm_sms_clickatell.php
@@ -430,10 +430,10 @@ class org_civicrm_sms_clickatell extends CRM_SMS_Provider {
    */
   function inbound() {
     $like      = "";
-    $fromPhone = $this->retrieve('from', 'String');
+    $fromPhone = $this->retrieve('fromNumber', 'String');
     $fromPhone = $this->formatPhone($this->stripPhone($fromPhone), $like, "like");
     
-    $body = $this->retrieve('text', 'String');
+    $body = urldecode($this->retrieve('text', 'String'));
     $charset = $this->retrieve('charset', 'String');
     if ($charset != 'UTF-8') {
       if (in_array($charset, mb_list_encodings())) {
@@ -443,7 +443,7 @@ class org_civicrm_sms_clickatell extends CRM_SMS_Provider {
         CRM_Core_Error::debug_log_message("Clickatell: mb_convert_encoding doesn't support incoming character set: '$charset'.");
       }
     }
-    return parent::processInbound($fromPhone, $body, NULL, $this->retrieve('moMsgId', 'String'));
+    return parent::processInbound($fromPhone, $body, NULL, $this->retrieve('messageId', 'String'));
   }
 
   /**


### PR DESCRIPTION
The inbound() function needed an update to match Click-a-tell's current API.  I'm not certain whether the urldecode() opens any potential security issues.

This address issue #29