### PR TITLE
php 8 fix for curl

### DIFF
--- a/org_civicrm_sms_clickatell.php
+++ b/org_civicrm_sms_clickatell.php
@@ -130,7 +130,7 @@ class org_civicrm_sms_clickatell extends CRM_SMS_Provider {
      * Reuse the curl handle
      */
     $this->_ch = curl_init();
-    if (!$this->_ch || !is_resource($this->_ch)) {
+    if ($this->_ch === FALSE) {
       return PEAR::raiseError('Cannot initialise a new curl handle.');
     }
 


### PR DESCRIPTION
Ih PHP 8.0+, `curl_init()` returns an object and not a resource, so this extension fails with a fatal error whenever you try to send an SMS.

This is a PHP-agnostic solution.  See also https://php.watch/versions/8.0/resource-CurlHandle#is-resource